### PR TITLE
fixes bug in prefs table when sorting columns

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -89,7 +89,7 @@
               <v-card-text>
                 <template>
 
-                  <v-data-table v-if="preferences && preferences[0] && preferences[0].preference_items"
+                  <v-data-table disable-sort v-if="preferences && preferences[0] && preferences[0].preference_items"
                     :headers="headers" :items="preferences[0].preference_items" class="elevation-1">
                     <template v-slot:[`item.l1`]="{ item }">
                       <v-checkbox v-model="item.l1"
@@ -134,7 +134,7 @@
                     </template>
 
                   </v-data-table>
-                  <v-data-table v-else :headers="headers" :items="tablePreferences.preference_items"
+                  <v-data-table disable-sort v-else :headers="headers" :items="tablePreferences.preference_items"
                     class="elevation-1">
                     <template v-slot:[`item.l1`]="{ item }">
                       <v-checkbox


### PR DESCRIPTION
Boxes display incorrect preferences during sorting of columns
![image](https://user-images.githubusercontent.com/109542090/186010802-68517d63-af7a-4f03-aaf5-55d7d7909be0.png)
